### PR TITLE
update localstack to 12.12 from 0.9.4

### DIFF
--- a/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
+++ b/modules/localstack/src/main/scala/com/dimafeng/testcontainers/LocalStackContainer.scala
@@ -23,7 +23,7 @@ case class LocalStackContainer(
 
 object LocalStackContainer {
 
-  val defaultTag = "0.9.4"
+  val defaultTag = "0.12.12"
 
   type Service = JavaLocalStackContainer.Service
 


### PR DESCRIPTION
I found I had to bump the `localstack` version to get sending of SQS messages using the AWS JDK 2 version to work